### PR TITLE
Edge member accessibility

### DIFF
--- a/src/edge.rs
+++ b/src/edge.rs
@@ -54,6 +54,38 @@ impl Edge {
         &self.id
     }
 
+    pub fn from_node(&self) -> &NodeId {
+        &self.from_node
+    }
+
+    pub fn from_side(&self) -> Option<&Side> {
+        self.from_side.as_ref()
+    }
+
+    pub fn from_end(&self) -> Option<&End> {
+        self.from_end.as_ref()
+    }
+
+    pub fn to_node(&self) -> &NodeId {
+        &self.to_node
+    }
+
+    pub fn to_side(&self) -> Option<&Side> {
+        self.to_side.as_ref()
+    }
+
+    pub fn to_end(&self) -> Option<&End> {
+        self.to_end.as_ref()
+    }
+
+    pub fn color(&self) -> Option<&Color> {
+        self.color.as_ref()
+    }
+
+    pub fn label(&self) -> Option<&String> {
+        self.label.as_ref()
+    }
+
     pub fn set_color(&mut self, color: Color) -> &mut Self {
         self.color = Some(color);
         self

--- a/src/jsoncanvas.rs
+++ b/src/jsoncanvas.rs
@@ -81,7 +81,7 @@ where
     let vec: Vec<Edge> = Vec::deserialize(deserializer)?;
     let map: HashMap<_, _> = vec
         .into_iter()
-        .map(|node| (node.id.clone(), node))
+        .map(|node| (node.id().clone(), node))
         .collect();
     Ok(map)
 }
@@ -96,19 +96,19 @@ impl JsonCanvas {
     }
 
     pub fn add_edge(&mut self, edge: Edge) -> Result<(), JsonCanvasError> {
-        if self.edges.contains_key(&edge.id) {
+        if self.edges.contains_key(edge.id()) {
             return Err(JsonCanvasError::EdgeExists(edge.id().clone()));
         }
 
-        if !self.nodes.contains_key(&edge.from_node) {
-            return Err(JsonCanvasError::NodeNotExists(edge.from_node.clone()));
+        if !self.nodes.contains_key(edge.from_node()) {
+            return Err(JsonCanvasError::NodeNotExists(edge.from_node().clone()));
         }
 
-        if !self.nodes.contains_key(&edge.to_node) {
-            return Err(JsonCanvasError::NodeNotExists(edge.to_node.clone()));
+        if !self.nodes.contains_key(edge.to_node()) {
+            return Err(JsonCanvasError::NodeNotExists(edge.to_node().clone()));
         }
 
-        self.edges.insert(edge.id.clone(), edge);
+        self.edges.insert(edge.id().clone(), edge);
         Ok(())
     }
 


### PR DESCRIPTION
I'm using `jsoncanvas` for a project, and was stopped short at one point by the inaccessibility of `Edge`'s members (besides `id`, `from_node`, and `to_node`):

```
pub struct Edge {
    pub id: EdgeId,
    pub from_node: NodeId,
    #[serde(skip_serializing_if = "Option::is_none")]
    from_side: Option<Side>,
    #[serde(skip_serializing_if = "Option::is_none")]
    from_end: Option<End>,
    pub to_node: NodeId,
    #[serde(skip_serializing_if = "Option::is_none")]
    to_side: Option<Side>,
    #[serde(skip_serializing_if = "Option::is_none")]
    to_end: Option<End>,
    #[serde(skip_serializing_if = "Option::is_none")]
    color: Option<crate::color::Color>,
    #[serde(skip_serializing_if = "Option::is_none")]
    label: Option<String>,
}
```

These private fields are [part of the spec](https://jsoncanvas.org/spec/1.0/) and it didn't seem to me that there was a particular reason to restrict access to them, so I added 'getter' methods in keeping with the signatures of other struct impls e.g. `Node`. I did not change struct-level visibility of any of the members; the prior interface is not broken.

Thanks!